### PR TITLE
Fix Purple Task For Manjaro Linux.

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -16,3 +16,7 @@
       source: .
       plugin: flutter
       flutter-target: lib/main.dart
+      stage-packages:
+      - libegl1
+      - libegl1-mesa
+      - libc6


### PR DESCRIPTION
Hello it seems that this software is not working on Manjaro Linux. With this error:

```BASH
(to_do:39026): dbind-WARNING **: 23:06:59.693: Couldn't connect to accessibility bus: Failed to connect to socket /tmp/dbus-CAvQFaIYSy: No such file or directory
Couldn't open libEGL.so.1: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.33' not found (required by /var/lib/snapd/lib/gl/libEGL.so.1)
```
I fixed it. Please merge this request and consider updating your snap on Snap Store.
Cheers.